### PR TITLE
Database.yml overwriting not the best idea

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -504,6 +504,7 @@ ERROR
   def create_database_yml
     log("create_database_yml") do
       return unless File.directory?("config")
+      return if File.exist?("config/database.yml")
       topic("Writing config/database.yml to read from DATABASE_URL")
       File.open("config/database.yml", "w") do |file|
         file.puts <<-DATABASE_YML


### PR DESCRIPTION
First of all the major problem is that this functionality causes problems with JDBC URLs.

I think this (unconditional) overwriting of database.yml is a bad idea. It would be better to allow the user to parse the ENV vars in the way he wants to. Additionally, Rails (at least 4.0.0) already parses DATABASE_URL so this file is kind of pointless then. With JDBC, URLs need to be prefixed with "jdbc:" (at least in certain cases), and that URI.parse cannot parse (same for ActiveRecord, unfortunately, it must be passed as url key in database.yml).

Since committing database.yml is a bad practice anyway, I suggest not to write this unless it does not exist (unfortunately since cf does not git this means adding it to .cfignore, although to be honest I don't understand why you don't simply use .gitignore).
Since you use DATABASE_URL it's probably not even necessary, even when the file is not there (since Rails will pick it up automatically). Also, to read from ENV manually is simple enough too:

``` yaml
production:
  adapter: postgresql
  url: "<%= ENV["DATABASE_URL"] %>"
```

In my opinion this overwriting functionality is not needed at all. When you want to operate with DATABASE_URL, Rails will handle it by itself anyway.

The other option is to special case for jdbc URLs, but then you also need to delete DATABASE_URL from ENV, or Rails will pick it up anyway, and it will still fail to work. Also then it is not possible to provide extra configuration like min_messages.
