### PR TITLE
run bundler with --retry to avoid network dodginess

### DIFF
--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -485,6 +485,7 @@ WARNING
         bundle_bin     = "bundle"
         bundle_command = "#{bundle_bin} install --without #{bundle_without} --path vendor/bundle --binstubs #{bundler_binstubs_path}"
         bundle_command << " -j4"
+        bundle_command << " --retry 3"
 
         if bundler.windows_gemfile_lock?
           warn(<<WARNING, inline: true)


### PR DESCRIPTION
We used to run `bundle package` prior to uploading our app to PWS - this seems to have stopped working and we've been battling some flakiness with our builds as a result.

A handy workaround is to make bundler retry if fetching fails - our app uses quite a few gems, and this seems to fix sporadic flakiness we experience when pushing.
