### PR TITLE
Add source mirror function during staging

### DIFF
--- a/cf_spec/fixtures/mirror_http/Gemfile
+++ b/cf_spec/fixtures/mirror_http/Gemfile
@@ -1,0 +1,3 @@
+source 'http://rubygems.org'
+
+gem 'sinatra'

--- a/cf_spec/fixtures/mirror_http/Gemfile.lock
+++ b/cf_spec/fixtures/mirror_http/Gemfile.lock
@@ -1,0 +1,21 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    rack (1.5.2)
+    rack-protection (1.5.2)
+      rack
+    sinatra (1.4.4)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (~> 1.3, >= 1.3.4)
+    tilt (1.4.1)
+
+PLATFORMS
+  ruby
+  x86-mingw32
+
+DEPENDENCIES
+  sinatra
+
+BUNDLED WITH
+   1.10.6

--- a/cf_spec/fixtures/mirror_http/README.md
+++ b/cf_spec/fixtures/mirror_http/README.md
@@ -1,0 +1,4 @@
+sinatra web app
+==================
+
+A service free app for CF buildpack testing

--- a/cf_spec/fixtures/mirror_http/app.rb
+++ b/cf_spec/fixtures/mirror_http/app.rb
@@ -1,0 +1,5 @@
+require 'sinatra'
+
+get '/' do
+  'Hello world!'
+end

--- a/cf_spec/fixtures/mirror_http/config.ru
+++ b/cf_spec/fixtures/mirror_http/config.ru
@@ -1,0 +1,2 @@
+require './app'
+run Sinatra::Application

--- a/cf_spec/fixtures/mirror_http_https/Gemfile
+++ b/cf_spec/fixtures/mirror_http_https/Gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gem 'sinatra'
+
+source 'http://rubygems.org' do
+  gem 'unicorn'
+end

--- a/cf_spec/fixtures/mirror_http_https/Gemfile.lock
+++ b/cf_spec/fixtures/mirror_http_https/Gemfile.lock
@@ -1,0 +1,29 @@
+GEM
+  remote: https://rubygems.org/
+  remote: http://rubygems.org/
+  specs:
+    kgio (2.10.0)
+    rack (1.6.4)
+    rack-protection (1.5.3)
+      rack
+    raindrops (0.15.0)
+    sinatra (1.4.6)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
+    tilt (2.0.1)
+    unicorn (5.0.1)
+      kgio (~> 2.6)
+      rack
+      raindrops (~> 0.7)
+
+PLATFORMS
+  ruby
+  x86-mingw32
+
+DEPENDENCIES
+  sinatra
+  unicorn!
+
+BUNDLED WITH
+   1.11.2

--- a/cf_spec/fixtures/mirror_http_https/README.md
+++ b/cf_spec/fixtures/mirror_http_https/README.md
@@ -1,0 +1,4 @@
+sinatra web app
+==================
+
+A service free app for CF buildpack testing

--- a/cf_spec/fixtures/mirror_http_https/app.rb
+++ b/cf_spec/fixtures/mirror_http_https/app.rb
@@ -1,0 +1,5 @@
+require 'sinatra'
+
+get '/' do
+  'Hello world!'
+end

--- a/cf_spec/fixtures/mirror_http_https/config.ru
+++ b/cf_spec/fixtures/mirror_http_https/config.ru
@@ -1,0 +1,2 @@
+require './app'
+run Sinatra::Application

--- a/cf_spec/fixtures/mirror_https/Gemfile
+++ b/cf_spec/fixtures/mirror_https/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'sinatra'

--- a/cf_spec/fixtures/mirror_https/Gemfile.lock
+++ b/cf_spec/fixtures/mirror_https/Gemfile.lock
@@ -1,0 +1,21 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    rack (1.5.2)
+    rack-protection (1.5.2)
+      rack
+    sinatra (1.4.4)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (~> 1.3, >= 1.3.4)
+    tilt (1.4.1)
+
+PLATFORMS
+  ruby
+  x86-mingw32
+
+DEPENDENCIES
+  sinatra
+
+BUNDLED WITH
+   1.10.6

--- a/cf_spec/fixtures/mirror_https/README.md
+++ b/cf_spec/fixtures/mirror_https/README.md
@@ -1,0 +1,4 @@
+sinatra web app
+==================
+
+A service free app for CF buildpack testing

--- a/cf_spec/fixtures/mirror_https/app.rb
+++ b/cf_spec/fixtures/mirror_https/app.rb
@@ -1,0 +1,5 @@
+require 'sinatra'
+
+get '/' do
+  'Hello world!'
+end

--- a/cf_spec/fixtures/mirror_https/config.ru
+++ b/cf_spec/fixtures/mirror_https/config.ru
@@ -1,0 +1,2 @@
+require './app'
+run Sinatra::Application

--- a/cf_spec/integration/mirror_http_https_spec.rb
+++ b/cf_spec/integration/mirror_http_https_spec.rb
@@ -1,0 +1,17 @@
+require 'cf_spec_helper'
+
+describe 'CF Ruby HTTP/HTTPS Mirror' do
+    
+  it 'replaces the sources successfully when ENV[GEM_SOURCE_MIRROR_HTTP] and ENV[GEM_SOURCE_MIRROR_HTTPS] are set correctly' do
+    app = Machete.deploy_app('mirror_http_https', env: {
+      GEM_SOURCE_MIRROR_HTTP: 'https://ruby.taobao.org',
+      GEM_SOURCE_MIRROR_HTTPS: 'https://ruby.taobao.org'
+    })
+    expect(app).to be_running
+    expect(app).to have_logged 'Running: bundle config mirror.http://rubygems.org https://ruby.taobao.org'
+    expect(app).to have_logged 'Running: bundle config mirror.https://rubygems.org https://ruby.taobao.org'
+    expect(app).to have_logged 'Fetching gem metadata from https://ruby.taobao.org/.....'
+    Machete::CF::DeleteApp.new.execute(app)
+  end
+  
+end

--- a/cf_spec/integration/mirror_http_spec.rb
+++ b/cf_spec/integration/mirror_http_spec.rb
@@ -1,0 +1,35 @@
+require 'cf_spec_helper'
+
+describe 'CF Ruby HTTP Mirror' do
+  
+  it 'displays the error info when ENV[GEM_SOURCE_MIRROR_HTTP] is set incorrectly' do
+    app = Machete.deploy_app('mirror_http', env: {
+      GEM_SOURCE_MIRROR_HTTP: 'ruby.taobao.org'
+    })
+    expect(app).to_not be_running
+    expect(app).to have_logged 'ArgumentError: Gem sources must be absolute.'
+    Machete::CF::DeleteApp.new.execute(app)
+  end
+  
+  it 'displays the error info when ENV[GEM_SOURCE_MIRROR_HTTP] is unavailable' do
+    app = Machete.deploy_app('mirror_http', env: {
+      GEM_SOURCE_MIRROR_HTTP: 'https://ruby.taoba0'
+    })
+    expect(app).to_not be_running
+    expect(app).to have_logged 'Running: bundle config mirror.http://rubygems.org https://ruby.taoba0'
+    expect(app).to have_logged 'Bundler::HTTPError Could not fetch specs from https://ruby.taoba0/'
+    Machete::CF::DeleteApp.new.execute(app)
+  end
+  
+  it 'replaces the source successfully when ENV[GEM_SOURCE_MIRROR_HTTP] is set correctly' do
+    app = Machete.deploy_app('mirror_http', env: {
+      GEM_SOURCE_MIRROR_HTTP: 'https://ruby.taobao.org'
+    })
+    expect(app).to be_running
+    expect(app).to have_logged 'Running: bundle config mirror.http://rubygems.org https://ruby.taobao.org'
+    expect(app).to have_logged 'Fetching gem metadata from https://ruby.taobao.org/.....'
+    Machete::CF::DeleteApp.new.execute(app)
+  end
+  
+  
+end

--- a/cf_spec/integration/mirror_https_spec.rb
+++ b/cf_spec/integration/mirror_https_spec.rb
@@ -1,0 +1,34 @@
+require 'cf_spec_helper'
+
+describe 'CF Ruby HTTPS Mirror' do
+ 
+  it 'displays the error info when ENV[GEM_SOURCE_MIRROR_HTTPS] is set incorrectly' do
+    app = Machete.deploy_app('mirror_https', env: {
+      GEM_SOURCE_MIRROR_HTTPS: 'ruby.taobao.org'
+    })
+    expect(app).to_not be_running
+    expect(app).to have_logged 'ArgumentError: Gem sources must be absolute.'
+    Machete::CF::DeleteApp.new.execute(app)
+  end
+  
+  it 'displays the error info when ENV[GEM_SOURCE_MIRROR_HTTPS] is unavailable' do
+    app = Machete.deploy_app('mirror_https', env: {
+      GEM_SOURCE_MIRROR_HTTPS: 'https://ruby.taoba0'
+    })
+    expect(app).to_not be_running
+    expect(app).to have_logged 'Running: bundle config mirror.https://rubygems.org https://ruby.taoba0'
+    expect(app).to have_logged 'Bundler::HTTPError Could not fetch specs from https://ruby.taoba0/'
+    Machete::CF::DeleteApp.new.execute(app)
+  end
+  
+  it 'replaces the source successfully when ENV[GEM_SOURCE_MIRROR_HTTPS] is set correctly' do
+    app = Machete.deploy_app('mirror_https', env: {
+      GEM_SOURCE_MIRROR_HTTPS: 'https://ruby.taobao.org'
+    })
+    expect(app).to be_running
+    expect(app).to have_logged 'Running: bundle config mirror.https://rubygems.org https://ruby.taobao.org'
+    expect(app).to have_logged 'Fetching gem metadata from https://ruby.taobao.org/.....'
+    Machete::CF::DeleteApp.new.execute(app)
+  end
+  
+end

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -537,6 +537,18 @@ WARNING
   def bundler_binstubs_path
     "vendor/bundle/bin"
   end
+  
+  def gem_source_http
+    "http://rubygems.org"
+  end
+  
+  def gem_source_https
+    "https://rubygems.org"
+  end	
+  
+  def mirror(mirror_param)
+    return !ENV[mirror_param].to_s.empty?
+  end
 
   # runs bundler to install the dependencies
   def build_bundler
@@ -590,6 +602,25 @@ WARNING
             "NOKOGIRI_USE_SYSTEM_LIBRARIES" => "true"
           }
           env_vars["BUNDLER_LIB_PATH"] = "#{bundler_path}" if ruby_version.ruby_version == "1.8.7"
+
+          #Add mirror support
+          if mirror("GEM_SOURCE_MIRROR_HTTP")
+            instrument "ruby.bundle_config" do
+              mirror_command = "#{bundle_bin} config mirror.#{gem_source_http} #{ENV['GEM_SOURCE_MIRROR_HTTP']}"
+              puts "Running: #{mirror_command}"
+              bundle_config_mirror = run_no_pipe("#{mirror_command}", env: env_vars, user_env: true)
+              error "Problem detecting bundler config mirror.http: #{bundle_config_mirror}" unless $?.success?
+            end
+          end
+          if mirror("GEM_SOURCE_MIRROR_HTTPS")
+            instrument "ruby.bundle_config" do
+              mirror_command = "#{bundle_bin} config mirror.#{gem_source_https} #{ENV['GEM_SOURCE_MIRROR_HTTPS']}"
+              puts "Running: #{mirror_command}"   
+              bundle_config_mirror = run_no_pipe("#{mirror_command}", env: env_vars, user_env: true)
+              error "Problem detecting bundler config mirror.https: #{bundle_config_mirror}" unless $?.success?
+            end
+          end
+	  
           puts "Running: #{bundle_command}"
           instrument "ruby.bundle_install" do
             bundle_time = Benchmark.realtime do


### PR DESCRIPTION
This request is to add source mirror function during staging. If user sets environment GEM_SOURCE_MIRROR_HTTP or GEM_SOURCE_MIRROR_HTTPS, the mirror config will be triggered. This function can be helpful in some places where the network access to "rubygems.org" is blocked, a mirror in local would be a good option.