### PR TITLE
Fix the problem with global ruby constants inside of application Gemfile

### DIFF
--- a/cf_spec/fixtures/manifests/Gemfile_with_const
+++ b/cf_spec/fixtures/manifests/Gemfile_with_const
@@ -1,0 +1,3 @@
+ruby "~> 8.2.7"
+
+gem 'thin' unless RUBY_PLATFORM =~ /mingw|mswin/i

--- a/cf_spec/unit/helpers/ruby_semver_version_spec.rb
+++ b/cf_spec/unit/helpers/ruby_semver_version_spec.rb
@@ -24,6 +24,13 @@ describe LanguagePack::RubySemverVersion do
         let(:gemfile) { File.join(fixtures, 'Gemfile_8_2_9') }
         it { should eq('') }
       end
+
+      context "gemfile with global ruby constants" do
+        let(:gemfile) { File.join(fixtures, 'Gemfile_with_const') }
+        it "don't raise an error" do
+          expect { subject }.to_not raise_error
+        end
+      end
     end
 
     context "unordered manifest" do

--- a/lib/language_pack/ruby_semver_version.rb
+++ b/lib/language_pack/ruby_semver_version.rb
@@ -47,6 +47,10 @@ module LanguagePack
 
       def method_missing *args
       end
+
+      def self.const_missing(name)
+        ::Object.const_get(name)
+      end
     end
   end
 end


### PR DESCRIPTION
**Description of the problem:**

The latest version of ruby-buildpack (v1.6.18) fails to run app with constants inside of `Gemfile`. For instance, if you'll add this line to your `Gemfile` file `gem 'thin' unless RUBY_PLATFORM =~ /mingw|mswin/i`, you get a following error during deploy: `uninitialized constant LanguagePack::RubySemverVersion::GemfileReader::ENV` ([full stacktrace](https://gist.github.com/allomov-altoros/aaa021bbbaec446e840fee94bfd726a9)). The problem is that `instance_eval` doesn't go further then `GemfileReader` searching constants. 

**Fix description:**

The fix I've implemented here was described in Ruby [docs](http://ruby-doc.org/core-2.2.0/BasicObject.html#method-i-instance_eval) in `BasicObject` article, I also added a test case that fails without my changes.

This issue was raised and discussed in [cf slack channel](https://cloudfoundry.slack.com/archives/buildpacks/p1464236456001043) by @avellable.