### PR TITLE
Remove libyaml

### DIFF
--- a/cf_spec/fixtures/sinatra_web_app/app.rb
+++ b/cf_spec/fixtures/sinatra_web_app/app.rb
@@ -1,5 +1,10 @@
 require 'sinatra'
+require 'yaml'
 
 get '/' do
   'Hello world!'
+end
+
+get '/yaml' do
+  YAML.load("{foo: [bar, baz, quux]}").to_yaml
 end

--- a/manifest.yml
+++ b/manifest.yml
@@ -12,9 +12,6 @@ url_to_dependency_map:
 - match: ruby-(\d+\.\d+\.\d+)
   name: ruby
   version: "$1"
-- match: libyaml-(\d+\.\d+\.\d+)
-  name: libyaml
-  version: "$1"
 - match: bundler-(\d+\.\d+\.\d+)
   name: bundler
   version: "$1"
@@ -31,12 +28,6 @@ url_to_dependency_map:
   name: node
   version: 4.5.0
 dependencies:
-- name: libyaml
-  version: 0.1.6
-  uri: https://buildpacks.cloudfoundry.org/ruby/binaries/cflinuxfs2/libyaml-0.1.6.tgz
-  md5: 94665f3a39e670507828f5084a40b669
-  cf_stacks:
-  - cflinuxfs2
 - name: bundler
   version: 1.13.1
   uri: https://buildpacks.cloudfoundry.org/concourse-binaries/bundler/bundler-1.13.1.tgz


### PR DESCRIPTION
Thanks for contributing to the buildpack. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

Remove explicit vendoring of libyaml in the ruby buildpack

* An explanation of the use cases your change solves

See GH issues from this morning

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

**Note** this is a proof-of-concept changeset intended to demonstrate that we no longer need to vendor libyaml. Feel free to close without merging, etc.