### PR TITLE
Updating version for jruby for 9.2.X

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -45,8 +45,8 @@ dependencies:
   source_sha256: b66d7c14f85075afdabb5ebf5950804c5a5d5c1d05ab833f580f04ee709b5773
 - name: jruby
   version: 9.2.11.1
-  uri: https://buildpacks.cloudfoundry.org/dependencies/jruby/jruby_9.2.11.1-ruby-2.5_linux_x64_cflinuxfs3_f6e02bcf.tgz
-  sha256: f6e02bcf02b7b33c48965b5c89adab4a2a9ebe20d345fd73d11cb4b1804df83f
+  uri: https://buildpacks.cloudfoundry.org/dependencies/jruby/jruby_9.2.11.1-ruby-2.5_linux_x64_cflinuxfs3_b596289d.tgz
+  sha256: b596289dd72b0db6ebbaa80fc728cd3402811d69ec2740be4f77ae8a57c12d2c
   cf_stacks:
   - cflinuxfs3
   source: https://s3.amazonaws.com/jruby.org/downloads/9.2.11.1/jruby-src-9.2.11.1.tar.gz


### PR DESCRIPTION
This PR is made automatically by release engineering bot.