### PR TITLE
Fix gem cleanup logic

### DIFF
--- a/src/ruby/supply/supply.go
+++ b/src/ruby/supply/supply.go
@@ -273,7 +273,7 @@ func (s *Supplier) RemoveUnusedRubyVersions(engine, version string) error {
 	}
 
 	for _, match := range matches {
-		if match != majorMinorVersion {
+		if !strings.HasSuffix(match, majorMinorVersion) {
 			err := os.RemoveAll(match)
 			if err != nil {
 				return err

--- a/src/ruby/supply/supply_test.go
+++ b/src/ruby/supply/supply_test.go
@@ -720,6 +720,7 @@ var _ = Describe("Supply", func() {
 				Expect(supplier.RemoveUnusedRubyVersions(selectedRubyEngine, selectedRubyVersion)).To(Succeed())
 
 				Expect(filepath.Join(depsDir, depsIdx, "vendor_bundle", selectedRubyEngine, "1.2.0")).ToNot(BeADirectory())
+				Expect(filepath.Join(depsDir, depsIdx, "vendor_bundle", selectedRubyEngine, "1.3.0")).To(BeADirectory())
 			})
 		})
 	})


### PR DESCRIPTION
All gems were being deleted from the cache during supply due to a bug in the ruby version cleanup logic. The code was comparing whole file paths with the ruby version.

This fixes that to check only the suffix of the file path for the ruby version, so that cached gems can be used again.

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have added an integration test

This is fixing a feature added without an integration test in [this commit](https://github.com/cloudfoundry/ruby-buildpack/commit/047c24752db32cf7e49a1012de1b0e0f400799cc), so we are not adding an integration test.
