### PR TITLE
Install node.js if cssbundling-rails or jsbundling-rails gems are used

### DIFF
--- a/src/ruby/supply/supply.go
+++ b/src/ruby/supply/supply.go
@@ -354,7 +354,7 @@ func (s *Supplier) NeedsNode() bool {
 	if s.isNodeInstalled() {
 		s.Log.BeginStep("Skipping install of nodejs since it has been supplied")
 	} else {
-		for _, name := range []string{"webpacker", "execjs"} {
+		for _, name := range []string{"webpacker", "execjs", "cssbundling-rails", "jsbundling-rails"} {
 			s.Log.Debug("Test %s in gemfile", name)
 			hasgem, err := s.Versions.HasGemVersion(name, ">=0.0.0")
 			if err == nil && hasgem {

--- a/src/ruby/supply/supply_test.go
+++ b/src/ruby/supply/supply_test.go
@@ -775,7 +775,25 @@ var _ = Describe("Supply", func() {
 					Expect(supplier.NeedsNode()).To(BeTrue())
 				})
 			})
-			Context("neither webpacker nor execjs are installed", func() {
+			Context("cssbundling-rails is installed", func() {
+				BeforeEach(func() {
+					mockVersions.EXPECT().HasGemVersion("cssbundling-rails", ">=0.0.0").Return(true, nil)
+					mockVersions.EXPECT().HasGemVersion(gomock.Any(), ">=0.0.0").AnyTimes().Return(false, nil)
+				})
+				It("returns true", func() {
+					Expect(supplier.NeedsNode()).To(BeTrue())
+				})
+			})
+			Context("jsbundling-rails is installed", func() {
+				BeforeEach(func() {
+					mockVersions.EXPECT().HasGemVersion("jsbundling-rails", ">=0.0.0").Return(true, nil)
+					mockVersions.EXPECT().HasGemVersion(gomock.Any(), ">=0.0.0").AnyTimes().Return(false, nil)
+				})
+				It("returns true", func() {
+					Expect(supplier.NeedsNode()).To(BeTrue())
+				})
+			})
+			Context("none of webpacker, execjs, cssbundling-rails, or jsbundling-rails are installed", func() {
 				BeforeEach(func() {
 					mockVersions.EXPECT().HasGemVersion(gomock.Any(), ">=0.0.0").AnyTimes().Return(false, nil)
 				})


### PR DESCRIPTION
Thanks for contributing to the buildpack. To speed up the process of reviewing your pull request please provide us with:

**A short explanation of the proposed change:**

Adds the [`jsbundling-rails`](https://github.com/rails/jsbundling-rails) and [`cssbundling-rails`](https://github.com/rails/cssbundling-rails) gems to the list of gems that cause NodeJS to be installed.

**An explanation of the use cases your change solves**

Without this change, a Rails 7 app that used either of these asset compilation gems that rely on nodejs would not, by default, have node available during asset compilation.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have added an integration test
