### PR TITLE
brats: fix jruby 9.4 tests

### DIFF
--- a/fixtures/brats_jruby/Gemfile
+++ b/fixtures/brats_jruby/Gemfile
@@ -6,6 +6,7 @@ gem 'nokogiri'
 gem 'sinatra'
 gem 'eventmachine'
 gem 'bcrypt'
+gem 'webrick'
 
 gem 'jdbc-mysql'
 gem 'jdbc-postgres'

--- a/src/ruby/brats/brats_suite_test.go
+++ b/src/ruby/brats/brats_suite_test.go
@@ -82,9 +82,9 @@ func CopyBrats(rubyVersion string) *cutlass.App {
 	return cutlass.New(dir)
 }
 
+// jruby 9.4.X.X = ruby 3.1.X
 // jruby 9.3.X.X = ruby 2.6.X
 // jruby 9.2.X.X = ruby 2.5.X
-// jruby 9.1.X.X = ruby 2.3.X
 func rubyVersionFromJRubyVersion(jrubyVersion string) (string, error) {
 	jrubyVersionRegex := regexp.MustCompile(`^(9.\d+).\d+.\d+$`)
 	version := jrubyVersionRegex.FindStringSubmatch(jrubyVersion)
@@ -92,12 +92,12 @@ func rubyVersionFromJRubyVersion(jrubyVersion string) (string, error) {
 		return "", fmt.Errorf("JRuby version is not of expected format: expected 9.X.X.X, got %s", jrubyVersion)
 	}
 	switch version[1] {
+	case "9.4":
+		return "~>3.1", nil
 	case "9.3":
 		return "~>2.6", nil
 	case "9.2":
 		return "~>2.5", nil
-	case "9.1":
-		return "~>2.3", nil
 	default:
 		return "", fmt.Errorf("Unknown JRuby -> Ruby version mapping for JRuby version %s", jrubyVersion)
 	}
@@ -145,15 +145,16 @@ func createGemfileLockFile(jrubyVersion string, fixtureDir string) error {
       racc (~> 1.4)
     racc (1.6.0-java)
     rack (2.2.4)
-    rack-protection (2.2.2)
+    rack-protection (2.2.3)
       rack
     ruby2_keywords (0.0.5)
-    sinatra (2.2.2)
+    sinatra (2.2.3)
       mustermann (~> 2.0)
       rack (~> 2.2)
-      rack-protection (= 2.2.2)
+      rack-protection (= 2.2.3)
       tilt (~> 2.0)
     tilt (2.0.11)
+    webrick (1.7.0)
 
 PLATFORMS
   universal-java-1.8
@@ -164,8 +165,9 @@ DEPENDENCIES
   jdbc-mysql
   jdbc-postgres
   nokogiri
-  sinatra`)
-	case "9.3":
+  sinatra
+  webrick`)
+	case "9.3", "9.4":
 		buffer = []byte(`GEM
   remote: https://rubygems.org/
   specs:
@@ -175,19 +177,20 @@ DEPENDENCIES
     jdbc-postgres (42.2.25)
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
-    nokogiri (1.13.8-java)
+    nokogiri (1.13.9-java)
       racc (~> 1.4)
     racc (1.6.0-java)
     rack (2.2.4)
-    rack-protection (3.0.2)
+    rack-protection (3.0.4)
       rack
     ruby2_keywords (0.0.5)
-    sinatra (3.0.2)
+    sinatra (3.0.4)
       mustermann (~> 3.0)
       rack (~> 2.2, >= 2.2.4)
-      rack-protection (= 3.0.2)
+      rack-protection (= 3.0.4)
       tilt (~> 2.0)
     tilt (2.0.11)
+    webrick (1.7.0)
 
 PLATFORMS
   universal-java-1.8
@@ -198,7 +201,8 @@ DEPENDENCIES
   jdbc-mysql
   jdbc-postgres
   nokogiri
-  sinatra`)
+  sinatra
+  webrick`)
 	default:
 		return fmt.Errorf("Unknown JRuby version %s, could not write Gemfile.lock", jrubyVersion)
 	}


### PR DESCRIPTION
- Turns out webrick is not part of the standard library from Ruby 3 onwards. So explicitly install it.
(https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/)


* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

