### PR TITLE
remove EOL'd jruby 9.2

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -40,14 +40,6 @@ dependencies:
   source: https://github.com/rubygems/rubygems/tree/master/bundlertree/v2.3.26
   source_sha256: 1ee53cdf61e728ad82c6dbff06cfcd8551d5422e88e86203f0e2dbe9ae999e09
 - name: jruby
-  version: 9.2.21.0
-  uri: https://buildpacks.cloudfoundry.org/dependencies/jruby/jruby_9.2.21.0-ruby-2.5_linux_x64_cflinuxfs3_612b3fbf.tgz
-  sha256: 612b3fbf9473f790574466db48f0609570d57f7536900e613c43e2b2163ed99c
-  cf_stacks:
-  - cflinuxfs3
-  source: https://s3.amazonaws.com/jruby.org/downloads/9.2.21.0/jruby-src-9.2.21.0.tar.gz
-  source_sha256: 11549eec6447ff82d28839645a9b73d3ec4bba2a9c88bfb4407282dea86ed81f
-- name: jruby
   version: 9.3.9.0
   uri: https://buildpacks.cloudfoundry.org/dependencies/jruby/jruby_9.3.9.0-ruby-2.6_linux_x64_cflinuxfs3_cbf4a951.tgz
   sha256: cbf4a95148b4b95507f5a6a3163d6689a7412d7ec4c0455cbe91e45e06ae3ea1

--- a/src/ruby/brats/brats_suite_test.go
+++ b/src/ruby/brats/brats_suite_test.go
@@ -84,7 +84,6 @@ func CopyBrats(rubyVersion string) *cutlass.App {
 
 // jruby 9.4.X.X = ruby 3.1.X
 // jruby 9.3.X.X = ruby 2.6.X
-// jruby 9.2.X.X = ruby 2.5.X
 func rubyVersionFromJRubyVersion(jrubyVersion string) (string, error) {
 	jrubyVersionRegex := regexp.MustCompile(`^(9.\d+).\d+.\d+$`)
 	version := jrubyVersionRegex.FindStringSubmatch(jrubyVersion)
@@ -96,8 +95,6 @@ func rubyVersionFromJRubyVersion(jrubyVersion string) (string, error) {
 		return "~>3.1", nil
 	case "9.3":
 		return "~>2.6", nil
-	case "9.2":
-		return "~>2.5", nil
 	default:
 		return "", fmt.Errorf("Unknown JRuby -> Ruby version mapping for JRuby version %s", jrubyVersion)
 	}
@@ -131,42 +128,6 @@ func createGemfileLockFile(jrubyVersion string, fixtureDir string) error {
 
 	var buffer []byte
 	switch version[1] {
-	case "9.2":
-		buffer = []byte(`GEM
-  remote: https://rubygems.org/
-  specs:
-    bcrypt (3.1.18-java)
-    eventmachine (1.2.7-java)
-    jdbc-mysql (8.0.27)
-    jdbc-postgres (42.2.25)
-    mustermann (2.0.2)
-      ruby2_keywords (~> 0.0.1)
-    nokogiri (1.12.5-java)
-      racc (~> 1.4)
-    racc (1.6.0-java)
-    rack (2.2.4)
-    rack-protection (2.2.3)
-      rack
-    ruby2_keywords (0.0.5)
-    sinatra (2.2.3)
-      mustermann (~> 2.0)
-      rack (~> 2.2)
-      rack-protection (= 2.2.3)
-      tilt (~> 2.0)
-    tilt (2.0.11)
-    webrick (1.7.0)
-
-PLATFORMS
-  universal-java-1.8
-
-DEPENDENCIES
-  bcrypt
-  eventmachine
-  jdbc-mysql
-  jdbc-postgres
-  nokogiri
-  sinatra
-  webrick`)
 	case "9.3", "9.4":
 		buffer = []byte(`GEM
   remote: https://rubygems.org/


### PR DESCRIPTION
The version is not published on the downloads page anymore (https://www.jruby.org/download)

See comment from Jruby team member:
https://github.com/jruby/jruby/issues/7496#issuecomment-1341603056


* [x] I have viewed signed and have submitted the Contributor License Agreement
* [x] I have made this pull request to the `develop` branch

