### PR TITLE
s/exists/exist: sub long deprecated api

### DIFF
--- a/fixtures/brats_ruby/Gemfile.lock
+++ b/fixtures/brats_ruby/Gemfile.lock
@@ -1,17 +1,17 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    bcrypt (3.1.16)
-    bson (4.12.0)
+    bcrypt (3.1.18)
+    bson (4.15.0)
     eventmachine (1.2.7)
     mini_portile2 (2.8.0)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
-    mysql2 (0.5.3)
-    nokogiri (1.13.9)
+    mysql2 (0.5.4)
+    nokogiri (1.13.10)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
-    pg (1.2.3)
+    pg (1.4.5)
     racc (1.6.0)
     rack (2.2.3)
     rack-protection (2.1.0)
@@ -39,7 +39,7 @@ DEPENDENCIES
   webrick
 
 RUBY VERSION
-   ruby 3.1.2p20
+   ruby 3.1.3p185
 
 BUNDLED WITH
-   2.3.7
+   2.3.26

--- a/src/ruby/versions/ruby.go
+++ b/src/ruby/versions/ruby.go
@@ -72,7 +72,7 @@ func (v *Versions) GetBundlerVersion() (string, error) {
 func (v *Versions) Engine() (string, error) {
 	gemfile := v.Gemfile()
 	code := fmt.Sprintf(`
-		b = Bundler::Dsl.evaluate('%s', '%s.lock', {}).ruby_version if File.exists?('%s')
+		b = Bundler::Dsl.evaluate('%s', '%s.lock', {}).ruby_version if File.exist?('%s')
 	  return 'ruby' if !b
 		b.engine
 	`, filepath.Base(gemfile), filepath.Base(gemfile), filepath.Base(gemfile))
@@ -305,7 +305,7 @@ func (v *Versions) run(dir, code string, in interface{}) (interface{}, error) {
 }
 
 func (v *Versions) BundledWithVersion() (string, error) {
-	code := fmt.Sprintf(`b = Bundler::LockfileParser.new(File.read("Gemfile.lock")).bundler_version if File.exists?("Gemfile.lock")
+	code := fmt.Sprintf(`b = Bundler::LockfileParser.new(File.read("Gemfile.lock")).bundler_version if File.exist?("Gemfile.lock")
 
 	return '' unless defined? b.version
 	b.version.to_s`)


### PR DESCRIPTION
The brats for ruby 3.2 has been failing with
"Running ruby: undefined method `exists?' for File:Class" (https://buildpacks.ci.cf-app.com/teams/main/pipelines/ruby-buildpack/jobs/specs-edge-integration-develop-cflinuxfs4/builds/16#L634b006e:349)

This is due to the use of deprecated File.exists api (https://ruby-doc.org/core-2.6.1/File.html#method-c-exists-3F)

Looks like support was fully removed in 3.2

Also: update to nokogiri that supports ruby 3.2

---

* [x] I have viewed signed and have submitted the Contributor License Agreement
* [x] I have made this pull request to the `develop` branch
