### PR TITLE
brats: remove nokogiri

### DIFF
--- a/fixtures/brats_jruby/Gemfile
+++ b/fixtures/brats_jruby/Gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 
 ruby '<%= ruby_version %>', engine: 'jruby', engine_version: '<%= engine_version %>'
 
-gem 'nokogiri'
 gem 'sinatra'
 gem 'eventmachine'
 gem 'bcrypt'

--- a/fixtures/brats_jruby/app.rb
+++ b/fixtures/brats_jruby/app.rb
@@ -1,5 +1,4 @@
 require 'sinatra'
-require 'nokogiri'
 require 'eventmachine'
 require 'bcrypt'
 require 'jdbc/mysql'
@@ -10,11 +9,6 @@ Jdbc::Postgres.load_driver
 
 get '/' do
   'Hello, World'
-end
-
-get '/nokogiri' do
-  doc = Nokogiri::XML(open('test.xml'))
-  doc.xpath('//xml')
 end
 
 get '/em' do

--- a/fixtures/brats_ruby/Gemfile
+++ b/fixtures/brats_ruby/Gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 
 ruby '<%= ruby_version %>'
 
-gem 'nokogiri'
 gem 'sinatra'
 gem 'eventmachine'
 gem 'bcrypt'

--- a/fixtures/brats_ruby/Gemfile.lock
+++ b/fixtures/brats_ruby/Gemfile.lock
@@ -4,15 +4,10 @@ GEM
     bcrypt (3.1.18)
     bson (4.15.0)
     eventmachine (1.2.7)
-    mini_portile2 (2.8.0)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
-    mysql2 (0.5.4)
-    nokogiri (1.13.10)
-      mini_portile2 (~> 2.8.0)
-      racc (~> 1.4)
+    mysql2 (0.5.3)
     pg (1.4.5)
-    racc (1.6.0)
     rack (2.2.3)
     rack-protection (2.1.0)
       rack
@@ -33,7 +28,6 @@ DEPENDENCIES
   bson
   eventmachine
   mysql2
-  nokogiri
   pg
   sinatra
   webrick

--- a/fixtures/brats_ruby/app.rb
+++ b/fixtures/brats_ruby/app.rb
@@ -2,7 +2,6 @@ require 'bcrypt'
 require 'bson'
 require 'eventmachine'
 require 'mysql2'
-require 'nokogiri'
 require 'pg'
 require 'sinatra'
 
@@ -12,11 +11,6 @@ end
 
 get '/version' do
   RUBY_VERSION
-end
-
-get '/nokogiri' do
-  doc = Nokogiri::XML(open('test.xml'))
-  doc.xpath('//xml')
 end
 
 get '/em' do

--- a/src/ruby/brats/brats_suite_test.go
+++ b/src/ruby/brats/brats_suite_test.go
@@ -138,17 +138,14 @@ func createGemfileLockFile(jrubyVersion string, fixtureDir string) error {
     jdbc-postgres (42.2.25)
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
-    nokogiri (1.13.9-java)
-      racc (~> 1.4)
-    racc (1.6.0-java)
-    rack (2.2.4)
-    rack-protection (3.0.4)
+    rack (2.2.5)
+    rack-protection (3.0.5)
       rack
     ruby2_keywords (0.0.5)
-    sinatra (3.0.4)
+    sinatra (3.0.5)
       mustermann (~> 3.0)
       rack (~> 2.2, >= 2.2.4)
-      rack-protection (= 3.0.4)
+      rack-protection (= 3.0.5)
       tilt (~> 2.0)
     tilt (2.0.11)
     webrick (1.7.0)
@@ -161,7 +158,6 @@ DEPENDENCIES
   eventmachine
   jdbc-mysql
   jdbc-postgres
-  nokogiri
   sinatra
   webrick`)
 	default:

--- a/src/ruby/brats/brats_test.go
+++ b/src/ruby/brats/brats_test.go
@@ -27,9 +27,6 @@ var _ = Describe("Ruby buildpack", func() {
 		By("runs a simple webserver", func() {
 			Expect(app.GetBody("/")).To(ContainSubstring("Hello World!"))
 		})
-		By("parses XML with nokogiri", func() {
-			Expect(app.GetBody("/nokogiri")).To(ContainSubstring("Hello, World"))
-		})
 		By("supports EventMachine", func() {
 			Expect(app.GetBody("/em")).To(ContainSubstring("Hello, EventMachine"))
 		})
@@ -66,9 +63,6 @@ var _ = Describe("Ruby buildpack", func() {
 		})
 		By("runs a simple webserver", func() {
 			Expect(app.GetBody("/")).To(ContainSubstring("Hello, World"))
-		})
-		By("parses XML with nokogiri", func() {
-			Expect(app.GetBody("/nokogiri")).To(ContainSubstring("Hello, World"))
 		})
 		By("supports EventMachine", func() {
 			Expect(app.GetBody("/em")).To(ContainSubstring("Hello, EventMachine"))


### PR DESCRIPTION
- With ruby 3.2, BRATS tests have been failing with Nokogiri complaining `nokogiri-1.13.10-x86_64-linux requires ruby version < 3.2.dev, >= 2.6, which is incompatible with the current version, 3.2.0` ([link](https://buildpacks.ci.cf-app.com/teams/main/pipelines/ruby-buildpack/jobs/specs-lts-brats-develop/builds/1052#L634b11da:311))
- Nokogiri seems to be pretty ruby-version dependent and thus not very suitable for a test suite like BRATS that runs on all supported versions
- BRATS already tests with webrick, bcrypt etc. So nokogiri is not really required
- Git history suggests that nokogiri has required maintenance of brats fixture through the years

* [x] I have viewed signed and have submitted the Contributor License Agreement
* [x] I have made this pull request to the `develop` branch