### PR TITLE
Adds java buildpack index

### DIFF
--- a/java-index/index.yml
+++ b/java-index/index.yml
@@ -1,0 +1,4 @@
+{
+  "3.1.3": "https://buildpacks.cloudfoundry.org/dependencies/ruby/ruby_3.1.3_linux_x64_cflinuxfs4_add107db.tgz",
+  "3.2.0": "https://buildpacks.cloudfoundry.org/dependencies/ruby/ruby_3.2.0_linux_x64_cflinuxfs4_eed4b6cb.tgz"
+}


### PR DESCRIPTION
This index allows the Java Buildpack to install a Ruby version to bootstrap itself. It is used in this code: https://github.com/cloudfoundry/java-buildpack/pull/995/files#diff-957b2a869d64e9da91361e2c728d7128b25f4a1d0295db42c2ac33e6831d515aR19

At some point in the future, we will add some automation to keep this set of Ruby versions up-to-date with what we ship in the Ruby buildpack itself.