### PR TITLE
Converts java-index to YAML

### DIFF
--- a/java-index/index.yml
+++ b/java-index/index.yml
@@ -1,0 +1,4 @@
+---
+3.1.3: https://buildpacks.cloudfoundry.org/dependencies/ruby/ruby_3.1.3_linux_x64_cflinuxfs4_add107db.tgz
+3.2.0: https://buildpacks.cloudfoundry.org/dependencies/ruby/ruby_3.2.0_linux_x64_cflinuxfs4_eed4b6cb.tgz
+3.2.1: https://buildpacks.cloudfoundry.org/dependencies/ruby/ruby_3.2.1_linux_x64_cflinuxfs4_3c69ef49.tgz


### PR DESCRIPTION
This adds an index file used by the Java buildpack to bootstrap itself with a Ruby interpreter when it runs on cflinuxfs4. See https://github.com/cloudfoundry/java-buildpack/pull/995 for further details.
