### PR TITLE
Bootstrap ruby before running

### DIFF
--- a/fixtures/jruby_start_command/Gemfile.lock
+++ b/fixtures/jruby_start_command/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
-    rack (2.2.6.4)
+    rack (2.2.3.1)
     rack-protection (2.2.0)
       rack
     ruby2_keywords (0.0.5)

--- a/fixtures/sinatra_jruby/Gemfile.lock
+++ b/fixtures/sinatra_jruby/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
-    rack (2.2.6.4)
+    rack (2.2.3.1)
     rack-protection (2.2.0)
       rack
     ruby2_keywords (0.0.5)


### PR DESCRIPTION
* A short explanation of the proposed change:
Now that `cflinuxfs4` no longer contains a Ruby runtime, we need to bootstrap ourselves so that we can later run some Ruby commands to figure out stuff like what version of Ruby we need to install.

* An explanation of the use cases your change solves
Resolves #764

* [x] I have viewed signed and have submitted the Contributor License Agreement
* [x] I have made this pull request to the `develop` branch
* [ ] I have added an integration test
