### PR TITLE
manifest: remove 3.1.2_cflinuxfs3

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -107,14 +107,6 @@ dependencies:
   source: https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.6.tar.gz
   source_sha256: 6e6cbd490030d7910c0ff20edefab4294dfcd1046f0f8f47f78b597987ac683e
 - name: ruby
-  version: 3.1.2
-  uri: https://buildpacks.cloudfoundry.org/dependencies/ruby/ruby_3.1.2_linux_x64_cflinuxfs3_2153ea21.tgz
-  sha256: 2153ea214f42ebe7c2db573b634e0a6dfdfd0c6c0824d25c161872af35247152
-  cf_stacks:
-  - cflinuxfs3
-  source: https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.2.tar.gz
-  source_sha256: 61843112389f02b735428b53bb64cf988ad9fb81858b8248e22e57336f24a83e
-- name: ruby
   version: 3.1.3
   uri: https://buildpacks.cloudfoundry.org/dependencies/ruby/ruby_3.1.3_linux_x64_cflinuxfs3_886f9a1c.tgz
   sha256: 886f9a1ccfa6bb5bc3686e9e118fa8e0a1884e875f6c33159353c174af7368df


### PR DESCRIPTION
It looks like the reason for the failure of dependency-update job (https://buildpacks.ci.cf-app.com/teams/main/pipelines/dependency-builds/jobs/update-ruby-3.1.x-ruby/builds/8) is due to the hanging ruby version that does not have a cflinuxfs4 equivalent.

