### PR TITLE
manifest: remove hanging ruby entry

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -90,7 +90,6 @@ dependencies:
   source: https://java-buildpack.cloudfoundry.org/openjdk-jdk/bionic/x86_64/openjdk-jdk-1.8.0_242-bionic.tar.gz
   source_sha256: dcb9fea2fc3a9b003031874ed17aa5d5a7ebbe397b276ecc8c814633003928fe
 - name: ruby
-- name: ruby
   version: 3.0.5
   uri: https://buildpacks.cloudfoundry.org/dependencies/ruby/ruby_3.0.5_linux_x64_cflinuxfs3_098393c3.tgz
   sha256: '098393c33a20af7638ff7183bbf184daf9b207b31e39f20a7fd00466823859b3'


### PR DESCRIPTION
This line seems to have been accidentally left out
when ruby 2.7 was removed a couple of days ago.

This should fix https://buildpacks.ci.cf-app.com/teams/main/pipelines/dependency-builds/jobs/update-ruby-3.1.x-ruby/builds/8

* [x] I have viewed signed and have submitted the Contributor License Agreement
* [x] I have made this pull request to the `develop` branch
