### PR TITLE
Add .manifest.json to list of files indicating local asset precompilation

### DIFF
--- a/src/ruby/finalize/finalize.go
+++ b/src/ruby/finalize/finalize.go
@@ -214,7 +214,7 @@ func (f *Finalizer) databaseUrl() string {
 }
 
 func (f *Finalizer) hasPrecompiledAssets() (bool, error) {
-	globs := []string{".sprockets-manifest-*.json", "manifest-*.json"}
+	globs := []string{".sprockets-manifest-*.json", "manifest-*.json", ".manifest.json"}
 	if f.RailsVersion < 4 {
 		globs = []string{"manifest.yml"}
 	}

--- a/src/ruby/finalize/finalize_test.go
+++ b/src/ruby/finalize/finalize_test.go
@@ -356,6 +356,17 @@ var _ = Describe("Finalize", func() {
 						Expect(buffer.String()).To(ContainSubstring("Detected assets manifest file, assuming assets were compiled locally"))
 					})
 				})
+				Context("public/assets/.manifest.json is present", func() {
+					BeforeEach(func() {
+						Expect(os.MkdirAll(filepath.Join(buildDir, "public", "assets"), 0755)).To(Succeed())
+						Expect(ioutil.WriteFile(filepath.Join(buildDir, "public", "assets", ".manifest.json"), []byte("memanifest"), 0644)).To(Succeed())
+					})
+					It("skips assets:precompile", func() {
+						Expect(finalizer.PrecompileAssets()).To(Succeed())
+						Expect(cmds).To(BeEmpty())
+						Expect(buffer.String()).To(ContainSubstring("Detected assets manifest file, assuming assets were compiled locally"))
+					})
+				})
 				Context("public/assets/manifest.yml is present", func() {
 					BeforeEach(func() {
 						Expect(os.MkdirAll(filepath.Join(buildDir, "public", "assets"), 0755)).To(Succeed())


### PR DESCRIPTION
## A short explanation of the proposed change:

* Adds `.manifest.json` to the list of files that indicate that assets were precompiled locally

## An explanation of the use cases your change solves

I'd like to skip any asset handling in the buildpack as I am doing it as part of my CI pipeline. Rails 8 & Propshaft introduced a new manifest file location that the buildpack wasn't yet checking

* [x] I have viewed signed and have submitted the Contributor License Agreement
* [x] I have made this pull request to the `develop` branch
* [x] I have added an ~integration~ unit test
