### PR TITLE
Add cflinuxfs5 to bundler and rubygems manifest entries

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -29,6 +29,7 @@ dependencies:
   sha256: cbc59f6dfcae65c6c5eaac1b748bc1c1a7120f6b73b3a723d56d8a7e2850dafc
   cf_stacks:
   - cflinuxfs4
+  - cflinuxfs5
   - cflinuxfs3
   source: https://github.com/rubygems/rubygems/tree/master/bundlertree/v2.6.5
   source_sha256: 9d0eef5779ee569c43f317484f034081f58e9cf7529af6cd59d15266e46a72a3
@@ -38,6 +39,7 @@ dependencies:
   sha256: 54c53519ff41ac0ad0d498086039f6ee2eac5d1bdef5ad31ab33e8ab2c2b1e21
   cf_stacks:
   - cflinuxfs4
+  - cflinuxfs5
   source: https://github.com/rubygems/rubygems/tree/master/bundlertree/v2.7.2
   source_sha256: 1decaf9e2e1acb91b6586a2925c8f3f6da2334a82731a62ff2ded1b83c283871
 - name: jruby
@@ -215,6 +217,7 @@ dependencies:
   sha256: 7a02eb5e5cf4ed6ad6a4245babf69f1f4c6acc1cbdf6d126dee8bf73dca7f8de
   cf_stacks:
   - cflinuxfs4
+  - cflinuxfs5
   - cflinuxfs3
   source: https://rubygems.org/rubygems/rubygems-3.6.8.tgz
   source_sha256: da5340b42ba3ddc5ede4a6b948ffa5b409d48cb119e2937e27e4c0b13bf9c390


### PR DESCRIPTION
### Add cflinuxfs5 to bundler and rubygems manifest entries 
bundler 2.6.5, bundler 2.7.2, and rubygems 3.6.8 are any-stack binaries but were missing cflinuxfs5 in their cf_stacks lists,
causing staging to fail with "no match found for 2.x.x in []" when running on cflinuxfs5.