### PR TITLE
Fix switchblade Initialize() multi-stack buildpack deletion

### DIFF
--- a/vendor/github.com/cloudfoundry/switchblade/internal/cloudfoundry/initialize.go
+++ b/vendor/github.com/cloudfoundry/switchblade/internal/cloudfoundry/initialize.go
@@ -43,7 +43,8 @@ func (i Initialize) Run(buildpacks []Buildpack) error {
 		if err == nil {
 			var payload struct {
 				Resources []struct {
-					Position int `json:"position"`
+					Position int    `json:"position"`
+					Stack    string `json:"stack"`
 				} `json:"resources"`
 			}
 			err = json.NewDecoder(buffer).Decode(&payload)
@@ -55,13 +56,19 @@ func (i Initialize) Run(buildpacks []Buildpack) error {
 				position = strconv.Itoa(payload.Resources[0].Position)
 			}
 
-			err = i.cli.Execute(pexec.Execution{
-				Args:   []string{"delete-buildpack", "-f", buildpack.Name},
-				Stdout: logs,
-				Stderr: logs,
-			})
-			if err != nil {
-				return fmt.Errorf("failed to delete buildpack: %s\n\nOutput:\n%s", err, logs)
+			for _, resource := range payload.Resources {
+				args := []string{"delete-buildpack", "-f", buildpack.Name}
+				if resource.Stack != "" {
+					args = append(args, "-s", resource.Stack)
+				}
+				err = i.cli.Execute(pexec.Execution{
+					Args:   args,
+					Stdout: logs,
+					Stderr: logs,
+				})
+				if err != nil {
+					return fmt.Errorf("failed to delete buildpack: %s\n\nOutput:\n%s", err, logs)
+				}
 			}
 		}
 


### PR DESCRIPTION
## Summary

Fix `cf delete-buildpack` failure in switchblade `Initialize()` when multiple
buildpacks share the same name across different stacks (cflinuxfs4 + cflinuxfs5).

## Problem

When CF has both cflinuxfs4 and cflinuxfs5 stacks deployed, buildpacks like
`ruby_buildpack` exist once per stack. The switchblade `Initialize()` method
called `cf delete-buildpack -f <name>` without `-s <stack>`, causing:

```
Multiple buildpacks named ruby_buildpack found.
Specify a stack name by using a '-s' flag and/or lifecycle using a '-l' flag.
FAILED
```

This broke the `create-cf-infrastructure-and-execute-integration-test-for-ruby`
pipeline job — all 5 retry attempts failed identically at `platform.Initialize()`.

## Fix

In the vendored `switchblade/internal/cloudfoundry/initialize.go`:

- Parse the `stack` field from the `/v3/buildpacks` API response
- Iterate over **all** resources (one per stack) and delete each with `-s <stack>`
- Guard with `if resource.Stack != ""` to handle any-stack buildpacks (null stack)

This is a vendored fix — the same bug exists in upstream switchblade v0.9.4.

## Testing

- `go build ./...` passes
- Docker-based switchblade tests are unaffected (different code path)
- CF integration tests should now pass with both cflinuxfs4 and cflinuxfs5