### PR TITLE
Upgrade switchblade to v0.9.5 (multi-stack delete fix)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/cloudfoundry/libbuildpack v0.0.0-20260306121953-8ab9253c8181
-	github.com/cloudfoundry/switchblade v0.9.4
+	github.com/cloudfoundry/switchblade v0.9.5
 	github.com/golang/mock v1.6.0
 	github.com/kr/text v0.2.0
 	github.com/onsi/ginkgo/v2 v2.28.1

--- a/go.sum
+++ b/go.sum
@@ -746,8 +746,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cloudflare/circl v1.1.0/go.mod h1:prBCrKB9DV4poKZY1l9zBXg2QJY7mvgRvtMxxK7fi4I=
 github.com/cloudfoundry/libbuildpack v0.0.0-20260306121953-8ab9253c8181 h1:di63teVid/uT+6TAqBSXFqxNM3sAbxk6hssYppZBvbw=
 github.com/cloudfoundry/libbuildpack v0.0.0-20260306121953-8ab9253c8181/go.mod h1:Qtj1XicpoDn88w2cvVCYtw1Whq+kK3bouin0xNZ9lIU=
-github.com/cloudfoundry/switchblade v0.9.4 h1:93O90a/DRRcZ4h50htDh4z7+FMliqy/lQH6IFgVa+mQ=
-github.com/cloudfoundry/switchblade v0.9.4/go.mod h1:hIEQdGAsuNnzlyQfsD5OIORt38weSBar6Wq5/JX6Omo=
+github.com/cloudfoundry/switchblade v0.9.5 h1:GTga1Uu6kGOL+n1TRTHyZm170N5/B/ou6wU90MiKKys=
+github.com/cloudfoundry/switchblade v0.9.5/go.mod h1:hIEQdGAsuNnzlyQfsD5OIORt38weSBar6Wq5/JX6Omo=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=

--- a/vendor/github.com/cloudfoundry/switchblade/internal/cloudfoundry/initialize.go
+++ b/vendor/github.com/cloudfoundry/switchblade/internal/cloudfoundry/initialize.go
@@ -43,7 +43,8 @@ func (i Initialize) Run(buildpacks []Buildpack) error {
 		if err == nil {
 			var payload struct {
 				Resources []struct {
-					Position int `json:"position"`
+					Position int    `json:"position"`
+					Stack    string `json:"stack"`
 				} `json:"resources"`
 			}
 			err = json.NewDecoder(buffer).Decode(&payload)
@@ -55,13 +56,20 @@ func (i Initialize) Run(buildpacks []Buildpack) error {
 				position = strconv.Itoa(payload.Resources[0].Position)
 			}
 
-			err = i.cli.Execute(pexec.Execution{
-				Args:   []string{"delete-buildpack", "-f", buildpack.Name},
-				Stdout: logs,
-				Stderr: logs,
-			})
-			if err != nil {
-				return fmt.Errorf("failed to delete buildpack: %s\n\nOutput:\n%s", err, logs)
+			for _, resource := range payload.Resources {
+				args := []string{"delete-buildpack", "-f", buildpack.Name}
+				if resource.Stack != "" {
+					args = append(args, "-s", resource.Stack)
+				}
+
+				err = i.cli.Execute(pexec.Execution{
+					Args:   args,
+					Stdout: logs,
+					Stderr: logs,
+				})
+				if err != nil {
+					return fmt.Errorf("failed to delete buildpack: %s\n\nOutput:\n%s", err, logs)
+				}
 			}
 		}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -29,7 +29,7 @@ github.com/cloudfoundry/libbuildpack/cutlass
 github.com/cloudfoundry/libbuildpack/cutlass/docker
 github.com/cloudfoundry/libbuildpack/cutlass/glow
 github.com/cloudfoundry/libbuildpack/packager
-# github.com/cloudfoundry/switchblade v0.9.4
+# github.com/cloudfoundry/switchblade v0.9.5
 ## explicit; go 1.23.0
 github.com/cloudfoundry/switchblade
 github.com/cloudfoundry/switchblade/internal/cloudfoundry


### PR DESCRIPTION
## Summary

- Upgrades `github.com/cloudfoundry/switchblade` from v0.9.4 to v0.9.5
- Fixes integration test failures when CF has multiple stacks (cflinuxfs4 + cflinuxfs5) deployed

## Problem

When both cflinuxfs4 and cflinuxfs5 stacks are available in the CF environment, `switchblade.Initialize()` calls `cf delete-buildpack -f <name>` without the `-s` flag. This fails with:

```
Multiple buildpacks named <name> found. Specify a stack name by using the '-s' flag.
```

## Fix

switchblade v0.9.5 (cloudfoundry/switchblade#126) iterates over all buildpack resources from the `/v3/buildpacks` API and uses `-s <stack>` when the resource has a non-empty stack field.

## Changes

Only 4 files changed (pure dependency upgrade):
- `go.mod` — v0.9.4 → v0.9.5
- `go.sum` — updated hashes
- `vendor/github.com/cloudfoundry/switchblade/internal/cloudfoundry/initialize.go` — the fix
- `vendor/modules.txt` — version bump