### PR TITLE
Fix JRuby timeout to respect CF platform limit (180s max)

### DIFF
--- a/fixtures/default/sinatra_jruby/manifest.yml
+++ b/fixtures/default/sinatra_jruby/manifest.yml
@@ -2,4 +2,4 @@
 applications:
 - name: sinatra_jruby_web_app
   health-check-type: process
-  timeout: 300
+  timeout: 180


### PR DESCRIPTION
## Problem

PR #1140 was merged with a change that increases the JRuby test app timeout to 300 seconds in `manifest.yml`. However, the CF platform deployment has a **hard limit of 180 seconds** configured via `cc.maximum_health_check_timeout`.

This causes deployment failures in CI:

```
For application 'switchblade-jojpj-2dr': health_check_timeout Maximum exceeded: max 180s
FAILED
```

## Root Cause

The CloudFoundry platform has this configuration that we cannot override:
```yaml
cc:
  maximum_health_check_timeout: 180
```

Any attempt to set `timeout: 300` in the manifest is rejected by the Cloud Controller.

## Solution

This PR reverts **only the manifest.yml change** from PR #1140, setting the timeout back to 180 seconds.

**What this PR keeps from #1140:**
- ✅ Test polling timeout increase (3min → 5min) - **This is correct and remains**
- ✅ Updated comments in test code
- ✅ The goal of reducing flaky failures

**What this PR reverts from #1140:**
- ❌ Manifest timeout increase (180s → 300s) - **This violates platform constraint**

## Changes

```diff
- timeout: 300
+ timeout: 180
```

Only 1 file, 1 line changed.

## Why The Original Goal Still Works

The test polling timeout (5 minutes) is **separate** from the CF health check timeout (180s):

1. **CF Health Check** (180s max):
   - CloudFoundry waits up to 180s for app to pass health check
   - App becomes "running" when health check passes
   - **This is a platform constraint we must respect**

2. **Test Polling Timeout** (5 minutes, increased in #1140):
   - Test waits up to 5 minutes for HTTP response from endpoint
   - Starts counting **after** app is marked as "running"
   - **This allows JRuby warmup time after health check passes**

**Timeline:**
- 0-180s: App starting, health check running
- 180s: Health check passes, app marked "running"
- 180-300s: JRuby warming up, test still polling
- 240s: JRuby ready, test succeeds

The 5-minute test timeout gives sufficient time for:
- Health check (up to 180s) + JRuby warmup (30-60s) = Total 210-240s

## Testing

This fix allows the test to:
- ✅ Deploy with valid 180s timeout (respects platform limit)
- ✅ Pass health check within 180s
- ✅ Have 5 minutes total for JRuby warmup
- ✅ Reduce flaky failures without violating constraints

## Related Issues

- Fixes: Deployment failures from PR #1140
- Related: PR #1088, PR #1090, PR #1134

## Impact

- ✅ Fixes immediate deployment failures
- ✅ Maintains flaky failure improvements from #1140
- ✅ Respects CF platform constraints
- ✅ No runtime behavior changes for buildpack users

## Priority

**Critical** - Current master is broken for environments with 180s timeout limit.