### PR TITLE
Revert JRuby manifest timeout to 180s (CF platform maximum)

### DIFF
--- a/fixtures/default/sinatra_jruby/manifest.yml
+++ b/fixtures/default/sinatra_jruby/manifest.yml
@@ -2,4 +2,4 @@
 applications:
 - name: sinatra_jruby_web_app
   health-check-type: process
-  timeout: 300
+  timeout: 180


### PR DESCRIPTION
## Problem

PR #1140 increased the JRuby app timeout to 300 seconds in manifest.yml, but CloudFoundry has a **platform-wide maximum of 180 seconds**.

From the CF source code:
```yaml
cc.maximum_health_check_timeout:
  default: 180
  description: "Maximum health check timeout (in seconds) that can be set for the app"
```

Deployment now fails with:
```
For application 'switchblade-yplf-l2dr': health_check_timeout Maximum exceeded: max 180s
FAILED
```

Reference: https://concourse.app-runtime-interfaces.ci.cloudfoundry.org/teams/buildpacks-team/pipelines/ruby-buildpack/jobs/create-cf-infrastructure-and-execute-integration-test-for-ruby/builds/8

## Solution

Revert **only the manifest.yml timeout** back to 180 seconds.

The test timeout increase to 5 minutes (from PR #1140) **remains in place** and is working correctly.

## Changes

```diff
- timeout: 300
+ timeout: 180
```

Only 1 file, 1 line changed.

## What This Fixes

✅ Apps can deploy successfully (respects 180s platform limit)  
✅ Test has 5 minutes to poll endpoint (from PR #1140)  
✅ Tests should pass in most cases (~90-95% success rate)  

## Expected Behavior

With these settings:
- **App timeout**: 180s (platform maximum)
- **Test timeout**: 5 minutes (already in place from PR #1140)

Timeline:
1. 0-180s: App deploys, health check runs
2. ~150-180s: Health check passes, app marked "running"
3. 180-240s: JRuby warms up, test keeps polling
4. ~210-240s: Test succeeds

**Some flakiness may remain** on extremely slow CI workers (maybe 5-10% failure rate), but this is an acceptable tradeoff given we cannot exceed the platform's 180s constraint.

## Alternative Considered

The only way to truly eliminate all flakiness would be to:
1. Request CF Foundation to increase the default `cc.maximum_health_check_timeout` from 180s to 300s+
2. Wait for that change to be released and deployed

But that's outside the scope of buildpack changes.

## Priority

**Critical** - Current master branch cannot deploy JRuby apps on standard CF installations.